### PR TITLE
add a github workflow that builds gbusb.uf2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,6 @@ jobs:
         cd build
         cmake ..
         make
-        pwd
-        echo ${{runner.workspace}}
-        echo $GITHUB_WORKSPACE
-        tree .
     - name: Release Development Build
       uses: "marvinpinto/action-automatic-releases@latest"
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Build gbusb.uf2
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Checkout Pico SDK
+      uses: actions/checkout@v2
+      with:
+        repository: raspberrypi/pico-sdk
+        path: pico-sdk
+        submodules: true
+    - name: Install Dependencies
+      run: |
+        sudo apt update
+        sudo apt install gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
+    - name: Build
+      run: |
+        export PICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk
+        mkdir build
+        cd build
+        cmake ..
+        make
+        pwd
+        echo ${{runner.workspace}}
+        echo $GITHUB_WORKSPACE
+        tree .
+    - name: Release Development Build
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "Development Build"
+        files: build/gbusb.uf2


### PR DESCRIPTION
builds the gbusb.uf2 file on every commit to main and uploads it as a github release so that you can flash your link cable adapter without setting up the pico sdk