### PR TITLE
Update vender device to new control xfer cb starting in tinyusb 0.11.0

### DIFF
--- a/main.c
+++ b/main.c
@@ -177,65 +177,68 @@ void tud_resume_cb(void)
 // WebUSB use vendor class
 //--------------------------------------------------------------------+
 
-// Invoked when received VENDOR control request
-bool tud_vendor_control_request_cb(uint8_t rhport, tusb_control_request_t const * request)
+// Invoked when a control transfer occurred on an interface of this class
+// Driver response accordingly to the request and the transfer stage (setup/data/ack)
+// return false to stall control endpoint (e.g unsupported request)
+bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request)
 {
-  switch (request->bRequest)
+  // nothing to do for DATA & ACK stage
+  if (stage != CONTROL_STAGE_SETUP) return true;
+
+  switch (request->bmRequestType_bit.type)
   {
-    case VENDOR_REQUEST_WEBUSB:
-      // match vendor request in BOS descriptor
-      // Get landing page url
-      return tud_control_xfer(rhport, request, (void*) &desc_url, desc_url.bLength);
-
-    case VENDOR_REQUEST_MICROSOFT:
-      if ( request->wIndex == 7 )
+    case TUSB_REQ_TYPE_VENDOR:
+      switch (request->bRequest)
       {
-        // Get Microsoft OS 2.0 compatible descriptor
-        uint16_t total_len;
-        memcpy(&total_len, desc_ms_os_20+8, 2);
+        case VENDOR_REQUEST_WEBUSB:
+          // match vendor request in BOS descriptor
+          // Get landing page url
+          return tud_control_xfer(rhport, request, (void*) &desc_url, desc_url.bLength);
 
-        return tud_control_xfer(rhport, request, (void*) desc_ms_os_20, total_len);
-      }else
-      {
-        return false;
+        case VENDOR_REQUEST_MICROSOFT:
+          if ( request->wIndex == 7 )
+          {
+            // Get Microsoft OS 2.0 compatible descriptor
+            uint16_t total_len;
+            memcpy(&total_len, desc_ms_os_20+8, 2);
+
+            return tud_control_xfer(rhport, request, (void*) desc_ms_os_20, total_len);
+          }else
+          {
+            return false;
+          }
+        default: break;
       }
+    break;
 
-    case 0x22:
-      // Webserial simulate the CDC_REQUEST_SET_CONTROL_LINE_STATE (0x22) to
-      // connect and disconnect.
-      web_serial_connected = (request->wValue != 0);
-
-      // Always lit LED if connected
-      if ( web_serial_connected )
+    case TUSB_REQ_TYPE_CLASS:
+      if (request->bRequest == 0x22)
       {
-        board_led_write(true);
-        blink_interval_ms = BLINK_ALWAYS_ON;
+        // Webserial simulate the CDC_REQUEST_SET_CONTROL_LINE_STATE (0x22) to connect and disconnect.
+        web_serial_connected = (request->wValue != 0);
 
-        // tud_vendor_write_str("\r\nTinyUSB WebUSB device example\r\n");
-      }else
-      {
-        blink_interval_ms = BLINK_MOUNTED;
+        // Always lit LED if connected
+        if ( web_serial_connected )
+        {
+          board_led_write(true);
+          blink_interval_ms = BLINK_ALWAYS_ON;
+
+          // tud_vendor_write_str("\r\nTinyUSB WebUSB device example\r\n");
+        }else
+        {
+          blink_interval_ms = BLINK_MOUNTED;
+        }
+
+        // response with status OK
+        return tud_control_status(rhport, request);
       }
+    break;
 
-      // response with status OK
-      return tud_control_status(rhport, request);
-
-    default:
-      // stall unknown request
-      return false;
+    default: break;
   }
 
-  return true;
-}
-
-// Invoked when DATA Stage of VENDOR's request is complete
-bool tud_vendor_control_complete_cb(uint8_t rhport, tusb_control_request_t const * request)
-{
-  (void) rhport;
-  (void) request;
-
-  // nothing to do
-  return true;
+  // stall unknown request
+  return false;
 }
 
 void webserial_task(void)


### PR DESCRIPTION
tinyusb 0.11.0 introduced a new control xfer cb interface and deprecated
the old one. This was made explicit through gcc poisoning of
`tud_vendor_control_request_cb` in https://github.com/hathach/tinyusb/pull/557